### PR TITLE
feat: Implement feature to detect duplicate tasks

### DIFF
--- a/data/tasks.txt
+++ b/data/tasks.txt
@@ -1,4 +1,2 @@
 T | X | go home
 D |   | read book | 2024-01-01T12:00
-T | X | read book
-T |   | gym

--- a/src/main/java/duke/exceptions/DukeDuplicateException.java
+++ b/src/main/java/duke/exceptions/DukeDuplicateException.java
@@ -1,0 +1,18 @@
+package duke.exceptions;
+
+/**
+ * The DukeDuplicateException class represents exceptions specific
+ * to invalid arguments in the Duke chatbot application.
+ * It extends the DukeException class.
+ */
+public class DukeDuplicateException extends DukeException {
+
+    /**
+     * Constructs a new DukeDuplicateException with the specified error message.
+     *
+     * @param errorMessage The error message associated with this exception.
+     */
+    public DukeDuplicateException(String errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/duke/ui/MainWindow.java
+++ b/src/main/java/duke/ui/MainWindow.java
@@ -7,8 +7,8 @@ import javafx.fxml.FXML;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
 import javafx.scene.image.Image;
-import javafx.scene.layout.Region;
 import javafx.scene.layout.AnchorPane;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 
 


### PR DESCRIPTION
Currently, the chatbox allows users to input duplicate tasks.

This might cause the list contain unnecessary tasks and make it difficult for users to find their tasks if the list is long.

Adding an error check for duplicates allows us to prevent users from adding duplicate tasks.

Let's add a new class, DukeDuplicateException, that extends DukeException. DukeDuplicateException will be thrown whenever a user tries to add a duplicate task.